### PR TITLE
Add embedding GPT deployment to main.bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -48,14 +48,23 @@ param openAiInstances object = {
   }
 }
 
-@description('Version of the Chat GPT model.')
-param chatGptModelVersion string = '0613'
-
 @description('SKU name for OpenAI.')
 param openAiSkuName string = 'S0'
 
+@description('Version of the Chat GPT model.')
+param chatGptModelVersion string = '0613'
+
 @description('Name of the Chat GPT deployment.')
 param chatGptDeploymentName string = 'chat'
+
+@description('Name of the Chat GPT model.')
+param embeddingGptModelName string = 'text-embedding-ada-002'
+
+@description('Version of the Chat GPT model.')
+param embeddingGptModelVersion string = '2'
+
+@description('Name of the Chat GPT deployment.')
+param embeddingGptDeploymentName string = 'embedding'
 
 @description('Name of the Chat GPT model.')
 param chatGptModelName string = 'gpt-35-turbo'
@@ -120,6 +129,18 @@ module openAis 'modules/ai/cognitiveservices.bicep' = [for (config, i) in items(
         }
         scaleSettings: {
           scaleType: 'Standard'
+        }
+      }
+      {
+        name: embeddingGptDeploymentName
+        model: {
+          format: 'OpenAI'
+          name: embeddingGptModelName
+          version: embeddingGptModelVersion
+        }
+        sku: {
+          name: 'Standard'
+          capacity: 1
         }
       }
     ]


### PR DESCRIPTION
This pull request primarily focuses on the `infra/main.bicep` file, introducing changes to the `openAiInstances` object and the `openAis` module. The most significant changes include the repositioning of the `chatGptModelVersion` parameter, the addition of parameters related to the `embeddingGpt` model, and the inclusion of a new configuration for the `embeddingGpt` model in the `openAis` module.

Repositioning and addition of parameters:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L51-R68): The `chatGptModelVersion` parameter was moved within the `openAiInstances` object for better organization. Additionally, new parameters such as `embeddingGptModelName`, `embeddingGptModelVersion`, and `embeddingGptDeploymentName` were introduced to describe a new `embeddingGpt` model.

Addition of a new configuration:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R134-R145): A new configuration for the `embeddingGpt` model was added to the `openAis` module. This configuration includes the model's format, name, version, and SKU details.