### PR TITLE
Update apim.bicep with additional dependencies

### DIFF
--- a/infra/modules/apim/apim.bicep
+++ b/infra/modules/apim/apim.bicep
@@ -158,6 +158,10 @@ resource openaiApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2022-08-
   }
   dependsOn: [
     openAiBackends
+    apiopenAiApiClientNamedValue
+    apiopenAiApiEntraNamedValue
+    apimOpenaiApiAudienceiNamedValue
+    apiopenAiApiTenantNamedValue
   ]
 }
 


### PR DESCRIPTION
This pull request includes changes to the `apim.bicep` file in the `infra/modules/apim` directory. The changes primarily involve adding dependencies to the `openaiApiPolicy` resource. Specifically, four new dependencies have been added: `apiopenAiApiClientNamedValue`, `apiopenAiApiEntraNamedValue`, `apimOpenaiApiAudienceiNamedValue`, and `apiopenAiApiTenantNamedValue`.

* [`infra/modules/apim/apim.bicep`](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aR161-R164): Added four new dependencies (`apiopenAiApiClientNamedValue`, `apiopenAiApiEntraNamedValue`, `apimOpenaiApiAudienceiNamedValue`, `apiopenAiApiTenantNamedValue`) to the `openaiApiPolicy` resource.