### PR TITLE
Update OpenAI deployment capacity parameter

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -69,6 +69,9 @@ param embeddingGptDeploymentName string = 'embedding'
 @description('Name of the Chat GPT model.')
 param chatGptModelName string = 'gpt-35-turbo'
 
+@description('The OpenAI endpoints capacity (in thousands of tokens per minute)')
+param deploymentCapacity int = 30
+
 @description('Tags to be applied to resources.')
 param tags object = { 'azd-env-name': environmentName }
 
@@ -125,7 +128,7 @@ module openAis 'modules/ai/cognitiveservices.bicep' = [for (config, i) in items(
     sku: {
       name: openAiSkuName
     }
-    deploymentCapacity: 1
+    deploymentCapacity: deploymentCapacity
     deployments: [
       {
         name: chatGptDeploymentName
@@ -147,7 +150,7 @@ module openAis 'modules/ai/cognitiveservices.bicep' = [for (config, i) in items(
         }
         sku: {
           name: 'Standard'
-          capacity: 1
+          capacity: deploymentCapacity
         }
       }
     ]

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -19,6 +19,12 @@
     },
     "entraAudience": {
       "value": "${AZURE_AUDIENCE}"
+    },
+    "deploymentCapacity": {
+      "value": "${OPENAI_CAPACITY}",
+      "metadata": {
+        "description": "The OpenAI endpoints capacity (in thousands of tokens per minute)."
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request primarily focuses on improving the deployment capacity configuration of the OpenAI endpoints in the `infra/main.bicep` file. The changes introduce a new parameter to specify the deployment capacity, and this parameter is then used to update the deployment and SKU capacities in the `openAis` module. Additionally, the `infra/main.parameters.json` file is updated to include this new parameter.

Here are the most important changes:

Deployment Capacity Configuration:

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R72-R74): Added a new parameter `deploymentCapacity` to specify the OpenAI endpoints capacity in thousands of tokens per minute.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L128-R131): Updated the `openAis` module to use the new `deploymentCapacity` parameter for setting the deployment capacity.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L150-R153): Updated the `openAis` module to use the new `deploymentCapacity` parameter for setting the SKU capacity.

Parameters File Update:

* [`infra/main.parameters.json`](diffhunk://#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13R22-R27): Added the new `deploymentCapacity` parameter with a description and a placeholder value.