### PR TITLE
Fixes Failing Cast for Remaining Backends when Client Connection to Backend is Dropped

### DIFF
--- a/apim-policy.xml
+++ b/apim-policy.xml
@@ -96,7 +96,7 @@
         <set-variable name="remainingBackends" value="1" />
     </inbound>
     <backend>
-        <retry condition="@(context.Response != null && (context.Response.StatusCode == 401 || context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && ((Int32)context.Variables["remainingBackends"]) > 0)" count="50" interval="0">
+        <retry condition="@(context.Response != null && (context.Response.StatusCode == 401 || context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && (int.Parse((string)context.Variables["remainingBackends"])) > 0)" count="50" interval="0">
             <!-- Before picking the backend, let's verify if there is any that should be set to not throttling anymore -->
             <set-variable name="listBackends" value="@{
                 JArray backends = (JArray)context.Variables["listBackends"];

--- a/infra/modules/apim/policies/api_policy.xml
+++ b/infra/modules/apim/policies/api_policy.xml
@@ -77,7 +77,7 @@
         <set-variable name="remainingBackends" value="1" />
     </inbound>
     <backend>
-        <retry condition="@(context.Response != null && (context.Response.StatusCode == 401 || context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && ((Int32)context.Variables["remainingBackends"]) > 0)" count="50" interval="0">
+        <retry condition="@(context.Response != null && (context.Response.StatusCode == 401 || context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && (int.Parse((string)context.Variables["remainingBackends"])) > 0)" count="50" interval="0">
             <!-- Before picking the backend, let's verify if there is any that should be set to not throttling anymore -->
             <set-variable name="listBackends" value="@{
                 JArray backends = (JArray)context.Variables["listBackends"];


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
Fixes a failing cast for remaining backends when the client connection to the backend is dropped. The `(Int32)` cast as it was fails. 

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Create a situation that causes the client connection to fail such as adding a `timeout-ms="1"` to the `forward-request`. Previously, the cast would fail. This PR fixes that and continues with the logic. 

Remove the `timeout-ms="1"` and run several requests against the load balancer to verify that backends are called appropriately based on availability.

## Other Information
Fixes #25 